### PR TITLE
Add log and stat injection for Lambda builds

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,11 +14,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f0efb70549251a537f06f31578b98ae7b856f7f067cc1cc41c1d6eadcc97928e"
+  digest = "1:fe321de7854c65af149fe7c66a7ed3ad82046902536e1aa41ec509f5fb942426"
   name = "github.com/asecurityteam/runhttp"
   packages = ["."]
   pruneopts = "UT"
-  revision = "59625dff40b30e0db17b88a6547a8e3232a57eda"
+  revision = "60620809c4931ced5fde6400c2462236cf3e9c16"
 
 [[projects]]
   branch = "master"
@@ -76,12 +76,12 @@
   version = "v2.2.2"
 
 [[projects]]
-  digest = "1:b60efdeb75d3c0ceed88783ac2495256aba3491a537d0f31401202579fd62a94"
+  digest = "1:be408f349cae090a7c17a279633d6e62b00068e64af66a582cae0983de8890ea"
   name = "github.com/golang/mock"
   packages = ["gomock"]
   pruneopts = "UT"
-  revision = "51421b967af1f557f93a59e0057aaf15ca02e29c"
-  version = "v1.2.0"
+  revision = "9fa652df1129bef0e734c9cf9bf6dbae9ef3b9fa"
+  version = "1.3.1"
 
 [[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
@@ -147,7 +147,7 @@
   name = "golang.org/x/net"
   packages = ["context"]
   pruneopts = "UT"
-  revision = "3a22650c66bd7f4fb6d1e8072ffd7b75c8a27898"
+  revision = "a4d6f7feada510cc50e69a37b484cb0fdc6b7876"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -157,6 +157,8 @@
     "github.com/asecurityteam/runhttp",
     "github.com/asecurityteam/settings",
     "github.com/aws/aws-lambda-go/lambda",
+    "github.com/aws/aws-lambda-go/lambda/messages",
+    "github.com/aws/aws-lambda-go/lambdacontext",
     "github.com/go-chi/chi",
     "github.com/go-chi/chi/middleware",
     "github.com/golang/mock/gomock",

--- a/domain.go
+++ b/domain.go
@@ -4,25 +4,32 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/asecurityteam/runhttp"
+	"github.com/asecurityteam/logevent"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/rs/xstats"
 )
 
 // Logger is an alias for the chosen project logging library
 // which is, currently, logevent. All references in the project
 // should be to this name rather than logevent directly.
-type Logger = runhttp.Logger
+type Logger = logevent.Logger
 
 // LogFn extracts a logger from the context.
-type LogFn = runhttp.LogFn
+type LogFn = func(context.Context) Logger
+
+// LoggerFromContext extracts the current logger.
+var LoggerFromContext = logevent.FromContext
 
 // Stat is an alias for the chosen project metrics library
 // which is, currently, xstats. All references in the project
 // should be to this name rather than xstats directly.
-type Stat = runhttp.Stat
+type Stat = xstats.XStater
 
 // StatFn extracts a metrics client from the context.
-type StatFn = runhttp.StatFn
+type StatFn = func(context.Context) Stat
+
+// StatFromContext extracts the current stat client.
+var StatFromContext = xstats.FromContext
 
 // Function is an executable lambda function. This extends
 // the official lambda SDK concept of a Handler in order to

--- a/logfunction.go
+++ b/logfunction.go
@@ -1,0 +1,32 @@
+package serverfull
+
+import (
+	"context"
+
+	"github.com/asecurityteam/logevent"
+)
+
+type loggingFunction struct {
+	Function
+	Logger Logger
+}
+
+func (f *loggingFunction) Invoke(ctx context.Context, b []byte) ([]byte, error) {
+	ctx = logevent.NewContext(ctx, f.Logger.Copy())
+	return f.Function.Invoke(ctx, b)
+}
+
+// loggingFetcher wraps the function in a decorator that injects a logger.
+type loggingFetcher struct {
+	Logger  Logger
+	Fetcher Fetcher
+}
+
+// Fetch calls the underlying Fetcher and adds log injection.
+func (f *loggingFetcher) Fetch(ctx context.Context, name string) (Function, error) {
+	r, err := f.Fetcher.Fetch(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return &loggingFunction{Logger: f.Logger, Function: r}, nil
+}

--- a/router.go
+++ b/router.go
@@ -3,7 +3,6 @@ package serverfull
 import (
 	"net/http"
 
-	"github.com/asecurityteam/runhttp"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 )
@@ -37,10 +36,10 @@ func applyDefaults(conf *RouterConfig) *RouterConfig {
 		conf.HealthCheck = "/healthcheck"
 	}
 	if conf.LogFn == nil {
-		conf.LogFn = runhttp.LoggerFromContext
+		conf.LogFn = LoggerFromContext
 	}
 	if conf.StatFn == nil {
-		conf.StatFn = runhttp.StatFromContext
+		conf.StatFn = StatFromContext
 	}
 	if conf.URLParamFn == nil {
 		conf.URLParamFn = chi.URLParamFromCtx

--- a/statfunction.go
+++ b/statfunction.go
@@ -1,0 +1,32 @@
+package serverfull
+
+import (
+	"context"
+
+	"github.com/rs/xstats"
+)
+
+type statFunction struct {
+	Function
+	Stat Stat
+}
+
+func (f *statFunction) Invoke(ctx context.Context, b []byte) ([]byte, error) {
+	ctx = xstats.NewContext(ctx, f.Stat)
+	return f.Function.Invoke(ctx, b)
+}
+
+// statFetcher wraps the function in a decorator that injects a stat client.
+type statFetcher struct {
+	Stat    Stat
+	Fetcher Fetcher
+}
+
+// Fetch calls the underlying Fetcher and adds stat client injection.
+func (f *statFetcher) Fetch(ctx context.Context, name string) (Function, error) {
+	r, err := f.Fetcher.Fetch(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return &statFunction{Stat: f.Stat, Function: r}, nil
+}


### PR DESCRIPTION
Some changes to the type aliases for logging and stat clients are
changed due to an edge case in the type system being triggered. The
exact details are commented near the installation of the new log and
stat decorators for the function fetcher where the edge case was
discovered.