### PR TITLE
Add ability to trigger errors in mock http mode

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -38,6 +38,7 @@ var StatFromContext = xstats.FromContext
 type Function interface {
 	lambda.Handler
 	Source() interface{}
+	Errors() []error
 }
 
 // URLParamFn should be accepted by HTTP handlers that need

--- a/function.go
+++ b/function.go
@@ -10,11 +10,30 @@ import (
 type LambdaFunction struct {
 	lambda.Handler
 	source interface{}
+	errors []error
 }
 
 // Source returns the original function signature.
 func (f *LambdaFunction) Source() interface{} {
 	return f.source
+}
+
+// Errors returns a list of errors the Lambda might return. This is
+// only populated if the function was constructed using the
+// NewFunctionWithErrors constructor.
+func (f *LambdaFunction) Errors() []error {
+	return f.errors
+}
+
+// NewFunctionWithErrors allows for documenting the various error types that
+// can be returned by the function. This may be used when running in mock + http
+// build modes to trigger exceptions.
+func NewFunctionWithErrors(v interface{}, errors ...error) Function {
+	return &LambdaFunction{
+		Handler: lambda.NewHandler(v),
+		source:  v,
+		errors:  errors,
+	}
 }
 
 // NewFunction is a replacement for lambda.NewHandler that returns

--- a/mfunction.go
+++ b/mfunction.go
@@ -34,7 +34,10 @@ func mockFunction(f Function) Function {
 	}
 	mockFn := newMockFn(returnType, returnsError)
 	newFn := reflect.MakeFunc(t, mockFn)
-	return NewFunction(newFn.Interface())
+	return NewFunctionWithErrors(
+		newFn.Interface(),
+		f.Errors()...,
+	)
 }
 
 func newMockFn(returnType reflect.Type, returnsError bool) func(args []reflect.Value) []reflect.Value {

--- a/mfunction_test.go
+++ b/mfunction_test.go
@@ -28,6 +28,7 @@ func TestMockingFetcher(t *testing.T) {
 
 	fetcher.EXPECT().Fetch(gomock.Any(), gomock.Any()).Return(fn, nil)
 	fn.EXPECT().Source().Return(testMFunc)
+	fn.EXPECT().Errors().Return(nil)
 
 	mfn, _ := mFetcher.Fetch(context.Background(), "test")
 	require.IsType(t, testMFunc, mfn.Source()) // ensure the mock is the right signature

--- a/mock_function_test.go
+++ b/mock_function_test.go
@@ -33,6 +33,20 @@ func (m *MockFunction) EXPECT() *MockFunctionMockRecorder {
 	return m.recorder
 }
 
+// Errors mocks base method
+func (m *MockFunction) Errors() []error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Errors")
+	ret0, _ := ret[0].([]error)
+	return ret0
+}
+
+// Errors indicates an expected call of Errors
+func (mr *MockFunctionMockRecorder) Errors() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Errors", reflect.TypeOf((*MockFunction)(nil).Errors))
+}
+
 // Invoke mocks base method
 func (m *MockFunction) Invoke(arg0 context.Context, arg1 []byte) ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/router.go
+++ b/router.go
@@ -29,6 +29,8 @@ type RouterConfig struct {
 	// The default value is chi.URLParam to match the usage of chi
 	// as a mux in the default case.
 	URLParamFn URLParamFn
+	// MockMode should be set to enable mock mode features like error simulation.
+	MockMode bool
 }
 
 func applyDefaults(conf *RouterConfig) *RouterConfig {
@@ -61,6 +63,7 @@ func NewRouter(conf *RouterConfig) *chi.Mux {
 		LogFn:      conf.LogFn,
 		StatFn:     conf.StatFn,
 		URLParamFn: conf.URLParamFn,
+		MockMode:   conf.MockMode,
 	}
 
 	router.Method(http.MethodPost, "/2015-03-31/functions/{functionName}/invocations", invokeHandler)

--- a/tests/port_test.go
+++ b/tests/port_test.go
@@ -1,0 +1,24 @@
+// +build integration
+
+package tests
+
+import (
+	"fmt"
+	"net"
+)
+
+// Copied from https://github.com/phayes/freeport.
+// BSD Licensed: https://github.com/phayes/freeport/blob/master/LICENSE.md
+func getPort() (string, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return "", err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return "", err
+	}
+	defer l.Close()
+	return fmt.Sprintf("%d", l.Addr().(*net.TCPAddr).Port), nil
+}

--- a/tests/start_test.go
+++ b/tests/start_test.go
@@ -5,6 +5,7 @@ package tests
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/rpc"
@@ -40,8 +41,9 @@ func logstat(ctx context.Context) {
 func TestStart(t *testing.T) {
 	ctx := context.Background()
 	functions := map[string]serverfull.Function{
-		"hello": serverfull.NewFunction(hello),
-		"error": serverfull.NewFunctionWithErrors(hello, errors.New("mock mode")),
+		"hello":   serverfull.NewFunction(hello),
+		"logstat": serverfull.NewFunction(logstat),
+		"error":   serverfull.NewFunctionWithErrors(hello, errors.New("mock mode")),
 	}
 	fetcher := &serverfull.StaticFetcher{Functions: functions}
 	// These tests are not safe to run in parallel but the subtest is parallel
@@ -52,7 +54,7 @@ func TestStart(t *testing.T) {
 
 	// makeHTTPCall attempts to execute the lambda over the invoke API until
 	// either a success case is found or the loop times out.
-	var makeHTTPCall = func(t *testing.T) error {
+	var makeHTTPCall = func(t *testing.T, port string) error {
 		// Ping the server until it is available or until we exceed a timeout
 		// value. This is to account for arbitrary start-up time of the server
 		// in the background.
@@ -60,7 +62,10 @@ func TestStart(t *testing.T) {
 		for time.Now().Before(stop) {
 			time.Sleep(100 * time.Millisecond)
 			resp, err := http.DefaultClient.Post(
-				"http://localhost:9090/2015-03-31/functions/hello/invocations",
+				fmt.Sprintf(
+					"http://localhost:%s/2015-03-31/functions/error/invocations",
+					port,
+				),
 				"application/json",
 				http.NoBody,
 			)
@@ -81,7 +86,7 @@ func TestStart(t *testing.T) {
 	}
 
 	// makeHTTPErrorCall attempts to execute the mock error simulation.
-	var makeHTTPErrorCall = func(t *testing.T) error {
+	var makeHTTPErrorCall = func(t *testing.T, port string) error {
 		// Ping the server until it is available or until we exceed a timeout
 		// value. This is to account for arbitrary start-up time of the server
 		// in the background.
@@ -90,7 +95,10 @@ func TestStart(t *testing.T) {
 			time.Sleep(100 * time.Millisecond)
 			req, _ := http.NewRequest(
 				http.MethodPost,
-				"http://localhost:9090/2015-03-31/functions/error/invocations",
+				fmt.Sprintf(
+					"http://localhost:%s/2015-03-31/functions/error/invocations",
+					port,
+				),
 				http.NoBody,
 			)
 			req.Header.Set("X-Amz-Invocation-Type", "Error")
@@ -121,14 +129,14 @@ func TestStart(t *testing.T) {
 
 	// makeRPCCall imitates the internal execution path for the native lambda
 	// system by using the net/rpc module.
-	var makeRPCCall = func(t *testing.T) error {
+	var makeRPCCall = func(t *testing.T, port string) error {
 		// Ping the server until it is available or until we exceed a timeout
 		// value. This is to account for arbitrary start-up time of the server
 		// in the background.
 		stop := time.Now().Add(5 * time.Second)
 		for time.Now().Before(stop) {
 			time.Sleep(100 * time.Millisecond)
-			client, err := rpc.Dial("tcp", "localhost:9090")
+			client, err := rpc.Dial("tcp", "localhost:"+port)
 			if err != nil {
 				t.Log(err.Error())
 				continue
@@ -150,31 +158,11 @@ func TestStart(t *testing.T) {
 		return errors.New("failed to execute function")
 	}
 
-	// Rather than mock out the settings.Source, it ends up being easier
-	// to manage and slightly more realistic to use the ENV source but
-	// populated with a static ENV list. This is easier because we don't
-	// need to mock out the internal call structure of the settings.Source
-	// which is largely irrelevant to this test. This is more realistic
-	// because it leverages the public configuration API of the project
-	// rather than internal knowledge of the settings project. For example,
-	// these ENV vars are exactly the ones that users would set when running
-	// the system.
-	source, err := settings.NewEnvSource([]string{
-		"SERVERFULL_RUNTIME_HTTPSERVER_ADDRESS=localhost:9090",
-		"SERVERFULL_RUNTIME_LOGGER_OUTPUT=NULL",
-		"SERVERFULL_RUNTIME_STATS_OUTPUT=NULL",
-	})
-	require.Nil(t, err)
-	// The native lambda function defines and manages its own set of environment
-	// variables that we can't patch or mock out other than setting them for the
-	// duration of the test. This variable defines the listening port for the RPC
-	// server.
-	os.Setenv("_LAMBDA_SERVER_PORT", "9090")
 	for _, testCase := range []struct {
 		BuildMode      string
 		MockMode       string
 		TargetFunction string
-		Execute        func(t *testing.T) error
+		Execute        func(t *testing.T, port string) error
 	}{
 		{
 			BuildMode:      serverfull.BuildModeHTTP,
@@ -235,6 +223,31 @@ func TestStart(t *testing.T) {
 			mut.Lock()
 			defer mut.Unlock()
 
+			port, err := getPort()
+			require.NoError(t, err)
+
+			// The native lambda function defines and manages its own set of environment
+			// variables that we can't patch or mock out other than setting them for the
+			// duration of the test. This variable defines the listening port for the RPC
+			// server.
+			os.Setenv("_LAMBDA_SERVER_PORT", port)
+
+			// Rather than mock out the settings.Source, it ends up being easier
+			// to manage and slightly more realistic to use the ENV source but
+			// populated with a static ENV list. This is easier because we don't
+			// need to mock out the internal call structure of the settings.Source
+			// which is largely irrelevant to this test. This is more realistic
+			// because it leverages the public configuration API of the project
+			// rather than internal knowledge of the settings project. For example,
+			// these ENV vars are exactly the ones that users would set when running
+			// the system.
+			source, err := settings.NewEnvSource([]string{
+				"SERVERFULL_RUNTIME_HTTPSERVER_ADDRESS=localhost:" + port,
+				"SERVERFULL_RUNTIME_LOGGER_OUTPUT=NULL",
+				"SERVERFULL_RUNTIME_STATS_OUTPUT=NULL",
+			})
+			require.Nil(t, err)
+
 			serverfull.BuildMode = testCase.BuildMode
 			serverfull.MockMode = testCase.MockMode
 			serverfull.TargetFunction = testCase.TargetFunction
@@ -242,7 +255,7 @@ func TestStart(t *testing.T) {
 			go func() {
 				exit <- serverfull.Start(ctx, source, fetcher)
 			}()
-			require.NoError(t, testCase.Execute(t))
+			require.NoError(t, testCase.Execute(t, port))
 			// The runtime establishes a signal handler for the entire
 			// process. This means we have the process signal itself and
 			// the runtime will intercept the call. This enables us to test


### PR DESCRIPTION
Add ability to document errors returned by any function.
Add special headers to trigger errors while in mock mode.

Note that only HTTP mode is supported as there is no mechanism for
conveying a trigger through vanilla lambda. If we were to build a real
or mock version of the lambda binary then the only way to interact with
it is through the real lambda API or through the real AWS API Gateway.
Neither of these enable us to add a trigger within a function or within
a function decorator because they do not convey the state that we need
without modifying the request body. As a result, this only works for
HTTP mode but can still be used to test serverfull-gateway templates.