### PR TITLE
Fix component usage to prevent nil pointer error

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,46 @@
 
 
 [[projects]]
+  digest = "1:6cbbc75cfbe13f5b3ee14c0395ba218144c8f72dc9d610057692c107e40fbab4"
+  name = "github.com/asecurityteam/component-connstate"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e8371614dbdbf67c13cb416c6b7366b0b4570bc4"
+  version = "v0.1.0"
+
+[[projects]]
+  digest = "1:50b6054c3166cb1490af953aca2fe787549c571072e90fb8977a063ca90c8883"
+  name = "github.com/asecurityteam/component-expvar"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "bf0d7879cb8dec94476c3861de4363767fa6e5f0"
+  version = "v0.1.0"
+
+[[projects]]
+  digest = "1:2e65af6319735cecabb4fd33ad796b04929c5656667f2f94cdeda25535d81b59"
+  name = "github.com/asecurityteam/component-log"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2a66e99dd017ee4200bb1483570af727995e6c5d"
+  version = "v0.1.0"
+
+[[projects]]
+  digest = "1:79c187e5b848602e1ab00b6bf1bc4b36b30b580cf3050590da6437caaffe6ec9"
+  name = "github.com/asecurityteam/component-signals"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "0d15bff7d1c866f9982eb1e70f84c5e4ef8e4854"
+  version = "v0.1.0"
+
+[[projects]]
+  digest = "1:535f5aab9d8b2a9451d81673b6bcdb342a304fb8de506a11b08ae0fe0e7f24f7"
+  name = "github.com/asecurityteam/component-stat"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "4175403694f83e388be7d0f20404aee8cbb64916"
+  version = "v0.1.0"
+
+[[projects]]
   digest = "1:ffadaa3e19072a02b4727002937b7a677973f2eed0a89b4a8c750576339bbaa5"
   name = "github.com/asecurityteam/logevent"
   packages = [
@@ -13,32 +53,33 @@
   version = "1.0.4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:fe321de7854c65af149fe7c66a7ed3ad82046902536e1aa41ec509f5fb942426"
+  digest = "1:07e44ec48d802cb92f337bfd3312aaced8d915a9934b60328f56a027c94138b7"
   name = "github.com/asecurityteam/runhttp"
   packages = ["."]
   pruneopts = "UT"
-  revision = "60620809c4931ced5fde6400c2462236cf3e9c16"
+  revision = "d57832e45684af266e155f7d068b1212cb6e7eda"
+  version = "v0.2.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:5d1a26a6e3312c38a5d2f498aabcddb2335278e1da07503da71b1b53e2f6992f"
+  digest = "1:391bbf4e67d50d74c1bb7dfad79222181327ff6d9a32324ed022b12051b5d5e8"
   name = "github.com/asecurityteam/settings"
   packages = ["."]
   pruneopts = "UT"
-  revision = "79c37a4bd1338811b72393481be2f9ca0315d162"
+  revision = "d4142d59861b3779aeba32111096d43ae940e49d"
+  version = "v0.1.0"
 
 [[projects]]
-  digest = "1:1c44f05197d518973df6d9371d4783035dd07ec1cb2049a6e799a59b2cc429b4"
+  digest = "1:019196f2ac870c197938d739cf0cdd4b78a39dc5c533021ed39899e390d34cd7"
   name = "github.com/aws/aws-lambda-go"
   packages = [
     "lambda",
+    "lambda/handlertrace",
     "lambda/messages",
     "lambdacontext",
   ]
   pruneopts = "UT"
-  revision = "527f5d301d2993af078be6d0b63372786b3fc18f"
-  version = "v1.8.2"
+  revision = "4c210d7623089d36b6bb6febf5a5e553bf73fbfb"
+  version = "v1.11.1"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
@@ -111,7 +152,7 @@
   revision = "c67367528e160e557423e4d87059614d8c31a582"
 
 [[projects]]
-  digest = "1:6112a5eaec2ec65df289ccbb7a730aaf03e3c5cce6c906d367ccf9b7ac567604"
+  digest = "1:ff8c32bee60523e39cd04e58b14fae0c3d6adcbc419e9e0c3d991af0390ab270"
   name = "github.com/rs/zerolog"
   packages = [
     ".",
@@ -119,8 +160,8 @@
     "internal/json",
   ]
   pruneopts = "UT"
-  revision = "8747b7b3a51b5d08ee7ac50eaf4869edaf9f714a"
-  version = "v1.11.0"
+  revision = "acf3980132bfcdc48638724e6e3d9e5749b85999"
+  version = "v1.14.3"
 
 [[projects]]
   digest = "1:08d65904057412fc0270fc4812a1c90c594186819243160dc779a402d4b6d0bc"
@@ -147,7 +188,7 @@
   name = "golang.org/x/net"
   packages = ["context"]
   pruneopts = "UT"
-  revision = "a4d6f7feada510cc50e69a37b484cb0fdc6b7876"
+  revision = "3b0461eec859c4b73bb64fdc8285971fd33e3938"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,11 +8,11 @@
 
 [[constraint]]
   name = "github.com/go-chi/chi"
-  version = "3.3.3"
+  version = "^3.3.3"
 
 [[constraint]]
   name = "github.com/asecurityteam/logevent"
-  version = "1.0.4"
+  version = "^1.0.4"
 
 [[constraint]]
   branch = "master"
@@ -20,16 +20,16 @@
 
 [[constraint]]
   name = "github.com/golang/mock"
-  version = "1.2.0"
+  version = "^1.2.0"
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.3.0"
+  version = "^1.3.0"
 
-[[constraint]]
+[[override]]
   name = "github.com/asecurityteam/runhttp"
-  branch = "master"
+  version = "^0.2.0"
 
-[[constraint]]
+[[override]]
   name = "github.com/asecurityteam/settings"
-  branch = "master"
+  version = "^0.1.0"

--- a/start.go
+++ b/start.go
@@ -22,7 +22,7 @@ func newRuntime(ctx context.Context, s settings.Source, f Fetcher) (*runhttp.Run
 		Fetcher: f,
 	}
 	router := NewRouter(conf)
-	rtC := &runhttp.Component{Handler: router}
+	rtC := runhttp.NewComponent().WithHandler(router)
 	rt := new(runhttp.Runtime)
 	err := settings.NewComponent(
 		ctx,
@@ -39,7 +39,7 @@ func newMockRuntime(ctx context.Context, s settings.Source, f Fetcher) (*runhttp
 		MockMode: true,
 	}
 	router := NewRouter(conf)
-	rtC := &runhttp.Component{Handler: router}
+	rtC := runhttp.NewComponent().WithHandler(router)
 	rt := new(runhttp.Runtime)
 	err := settings.NewComponent(
 		ctx,


### PR DESCRIPTION
I missed this spot during the refactor. We didn't catch it because most
things are pinned to a specific version of both runhttp and serverfull.
Pulling in the latest deps results in a crash from serverfull because it
doesn't initialize all the runhttp items correctly.