### PR TITLE
Fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a id="markdown-serverfull---a-lambda-simulator-for-go" name="serverfull---a-lambda-simulator-for-go"></a>
 # Serverfull - A Lambda Simulator For Go
 [![GoDoc](https://godoc.org/github.com/asecurityteam/serverfull?status.svg)](https://godoc.org/github.com/asecurityteam/serverfull)
-[![Build Status](https://travis-ci.org/asecurityteam/serverfull.png?branch=master)](https://travis-ci.org/asecurityteam/serverfull)
+[![Build Status](https://travis-ci.com/asecurityteam/serverfull.png?branch=master)](https://travis-ci.com/asecurityteam/serverfull)
 [![codecov.io](https://codecov.io/github/asecurityteam/serverfull/coverage.svg?branch=master)](https://codecov.io/github/asecurityteam/serverfull?branch=master)
 <!-- TOC -->
 


### PR DESCRIPTION
Open source repos in travis-ci.org are migrated to travis-ci.com.